### PR TITLE
Host on Github Pages Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: Gray
 email: email@email.com
 description: >- # this means to ignore newlines until "baseurl:"
   Lorem Ipsum
-url: "https://brunofolle.com.br" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://brunofolle.github.io/gray/" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "/" # the subpath of your site, e.g. /blog
 
 # Build settings


### PR DESCRIPTION
The domain https://brunofolle.com.br/ is not viewable, why don't host in github pages?